### PR TITLE
[#23] Lower bundle size drastically

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@
 
 ## Installing
 
-Install ``filestack-react`` through npm
+Install ``filestack-react`` and ``filestack-js`` through npm
 
 ```shell
-npm install filestack-react
+npm install filestack-react filestack-js
 ```
 or
 ```shell
-yarn add filestack-react
+yarn add filestack-react filestack-js
 ```
 ## Import
 ```javascript

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "react component for filestack",
   "scripts": {
     "test": "jest --watch --no-cache --coverage",
-    "build": "rimraf dist && webpack --colors --debug --display-error-details",
+    "build": "rimraf dist && webpack --colors -p --display-error-details",
     "prepublish": "npm run build",
     "lint": "eslint"
   },
@@ -66,8 +66,9 @@
     "style-loader": "^0.16.0",
     "webpack": "^2.3.2"
   },
-  "dependencies": {
-    "filestack-js": "^0.9.1"
+  "peerDependencies": {
+    "filestack-js": "^0.9.8",
+    "react": "^15.5.4"
   },
   "jest": {
     "roots": [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,7 +8,7 @@ module.exports = {
   output: {
     path: path.join(__dirname, 'dist'),
     filename: 'filestack-react.js',
-    libraryTarget: 'commonjs2',
+    libraryTarget: 'umd',
   },
   devtool: 'source-map',
   resolve: {
@@ -16,6 +16,9 @@ module.exports = {
     extensions: ['.js', '.json', '.jsx'],
   },
   module: { rules },
+  externals: [
+    'react', 'filestack-js', 'prop-types'
+  ],
   plugins: [
     new webpack.LoaderOptionsPlugin({
       minimize: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2129,10 +2129,6 @@ fileset@^2.0.2:
     glob "^7.0.3"
     minimatch "^3.0.3"
 
-filestack-js@^0.9.1:
-  version "0.9.1"
-  resolved "https://registry.yarnpkg.com/filestack-js/-/filestack-js-0.9.1.tgz#8591dba23c0f1a227631233df6f2f07cb81a6c4d"
-
 fill-range@^2.1.0:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-2.2.3.tgz#50b77dfd7e469bc7492470963699fe7a8485a723"


### PR DESCRIPTION
**Before this PR:**
![image](https://user-images.githubusercontent.com/6998322/31604852-dc18a128-b264-11e7-8330-5c3984fbca1c.png)
Total files size: 131 kB.

**After this PR:**
![image](https://user-images.githubusercontent.com/6998322/31604903-02f27e54-b265-11e7-8eb8-0c815dc25a06.png)
Total files size: 4.19kB.

Usage of the library does not change whatsoever. Only difference is, that you have to install `filestack-js` library separately. This also allows you to update `filestack-js` independently from React-Filestack.

Bundle is significantly lower, as you used to send built React, filestack-js and prop-types alongside with React-Filestack.


This resolves #23 